### PR TITLE
Fix issues With Unity Network Module and Unity's Assembly Definitions

### DIFF
--- a/Assets/OpenTerminal/Sample/RotateCube.cs
+++ b/Assets/OpenTerminal/Sample/RotateCube.cs
@@ -12,20 +12,20 @@ public class RotateCube : MonoBehaviour
     }
 
 
-    [Command("stop-cube", "stops the cube from rotating")]
+    [TerminalCommand("stop-cube", "stops the cube from rotating")]
     public void StopCube()
     {
         stop = true;
     }
 
 
-    [Command("rotate-cube", "rotates the cube")]
+    [TerminalCommand("rotate-cube", "rotates the cube")]
     public void RotateTheCube()
     {
         stop = false;
     }
 
-    [Command("move-cube", "move-cube(x,y,z) Moves the cube")]
+    [TerminalCommand("move-cube", "move-cube(x,y,z) Moves the cube")]
     public void Move(float x, float y, float z)
     {
         transform.position = new Vector3(x, y, z);

--- a/Assets/OpenTerminal/Scripts/BasicCommands.cs
+++ b/Assets/OpenTerminal/Scripts/BasicCommands.cs
@@ -3,13 +3,13 @@ using UnityEngine;
 public class BasicCommands
 {
 
-    [Command("clear", "clears the terminal screen")]
+    [TerminalCommand("clear", "clears the terminal screen")]
     public void ClearTerminal()
     {
         Terminal.instance.Clear();
     }
 
-    [Command("help", "Shows list of available commands")]
+    [TerminalCommand("help", "Shows list of available commands")]
     public string Help()
     {
         string help_string = "List of available commands:";
@@ -17,9 +17,9 @@ public class BasicCommands
         {
             foreach (var attribute in method.GetCustomAttributes(true))
             {
-                if (attribute is CommandAttribute) //Does not pass
+                if (attribute is TerminalCommandAttribute) //Does not pass
                 {
-                    CommandAttribute attr = (CommandAttribute)attribute;
+                    TerminalCommandAttribute attr = (TerminalCommandAttribute)attribute;
                     help_string += "\n      " + attr.commandName + " --> " + attr.commandDesc;
                 }
             }
@@ -27,7 +27,7 @@ public class BasicCommands
         return help_string;
     }
 
-    [Command("hide", "Hides the terminal")]
+    [TerminalCommand("hide", "Hides the terminal")]
     public void Hide()
     {
         Terminal.instance.Hide();

--- a/Assets/OpenTerminal/Scripts/SampleCommand.cs
+++ b/Assets/OpenTerminal/Scripts/SampleCommand.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 public class SampleCommand
 {
-    [Command("debug", "Debugs a sample line in Unity Console")]
+    [TerminalCommand("debug", "Debugs a sample line in Unity Console")]
     public void SampleDebug(string input)
     {
         Debug.Log(input);

--- a/Assets/OpenTerminal/Scripts/Terminal.cs
+++ b/Assets/OpenTerminal/Scripts/Terminal.cs
@@ -116,9 +116,9 @@ public class Terminal : MonoBehaviour
         foreach (var method in terminalMethods.methods)
         {
             foreach (object attribute in method.GetCustomAttributes(true)) // Returns all 3 of my attributes.
-                if (attribute is CommandAttribute)
+                if (attribute is TerminalCommandAttribute)
                 {
-                    CommandAttribute attr = (CommandAttribute)attribute;
+                    TerminalCommandAttribute attr = (TerminalCommandAttribute)attribute;
                     if (attr.commandName == command)
                     {
                         if (registered) Debug.LogError(TerminalStrings.MULTIPLE_COMMAND_NAMES + command);

--- a/Assets/OpenTerminal/Scripts/TerminalAttribute.cs
+++ b/Assets/OpenTerminal/Scripts/TerminalAttribute.cs
@@ -1,16 +1,16 @@
 using System;
 using UnityEngine;
 [AttributeUsage(AttributeTargets.Method)]
-public class CommandAttribute : Attribute
+public class TerminalCommandAttribute : Attribute
 {
     public string commandName;
     public string commandDesc;
 
-    public CommandAttribute(string name)
+    public TerminalCommandAttribute(string name)
     {
         commandName = name;
     }
-    public CommandAttribute(string name, string desc)
+    public TerminalCommandAttribute(string name, string desc)
     {
         commandName = name;
         commandDesc = desc;

--- a/Assets/OpenTerminal/Scripts/TerminalMethods.cs
+++ b/Assets/OpenTerminal/Scripts/TerminalMethods.cs
@@ -10,19 +10,18 @@ public class TerminalMethods
     public TerminalMethods()
     {
         methods = new List<MethodInfo>();
-        var assembly = System.AppDomain.CurrentDomain.Load("Assembly-CSharp");
-        methods = assembly
-            .GetTypes()
-            .SelectMany(x => x.GetMethods())
-            .Where(y => y.GetCustomAttributes(true).OfType<CommandAttribute>().Any()).ToList();
-        foreach (var method in methods)
+
+        foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
-            foreach (var attribute in method.GetCustomAttributes(true))
+            foreach (var method in assembly.GetTypes().SelectMany(x => x.GetMethods()).Where(y => y.GetCustomAttributes(true).OfType<TerminalCommandAttribute>().Any()).ToList())
             {
-                if (attribute is CommandAttribute) //Does not pass
+                foreach (var attribute in method.GetCustomAttributes(true))
                 {
-                    CommandAttribute attr = (CommandAttribute)attribute;
-                    methodNames.Add(attr.commandName);
+                    if (attribute is TerminalCommandAttribute) //Does not pass
+                    {
+                        TerminalCommandAttribute attr = (TerminalCommandAttribute)attribute;
+                        methodNames.Add(attr.commandName);
+                    }
                 }
             }
         }

--- a/Assets/OpenTerminal/Scripts/TerminalMethods.cs
+++ b/Assets/OpenTerminal/Scripts/TerminalMethods.cs
@@ -11,10 +11,11 @@ public class TerminalMethods
     {
         methods = new List<MethodInfo>();
 
-        foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
         {
             foreach (var method in assembly.GetTypes().SelectMany(x => x.GetMethods()).Where(y => y.GetCustomAttributes(true).OfType<TerminalCommandAttribute>().Any()).ToList())
             {
+                methods.Add(method)
                 foreach (var attribute in method.GetCustomAttributes(true))
                 {
                     if (attribute is TerminalCommandAttribute) //Does not pass


### PR DESCRIPTION
Unity NetworkBehavior already Uses Command as Attribute for Server Execution
Ref: https://docs.unity3d.com/ScriptReference/Networking.CommandAttribute.html

Also, Unity introduced with Unity 2017 assembly definition.
Ref: https://docs.unity3d.com/Manual/ScriptCompilationAssemblyDefinitionFiles.html